### PR TITLE
from just router to assistant

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,25 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+
+        {
+            "name": "LangGraph : Attach",
+            "type": "debugpy",
+            "request": "attach",
+            "connect": {
+                "host": "localhost",
+                "port": 2025
+            },
+            "pathMappings": [
+                {
+                    "localRoot": "${workspaceFolder}",
+                    "remoteRoot": "."
+                }
+            ],
+            "justMyCode": true
+        }
+    ]
+}

--- a/README.md
+++ b/README.md
@@ -43,6 +43,21 @@ langgraph dev
 
 `langgraph dev` should automatically take you to: https://smith.langchain.com/studio/?baseUrl=http://locahost:2024
 
+## Try
+
+### Build the Router
+- Go to **Studio UI**: https://smith.langchain.com/studio/?baseUrl=http://locahost:2024
+- Select the **build_router** graph (if not already selected)
+- Go to **Configurations > MCP Server Config**
+- Add your MCP server configurations in the standard format. [Here's a sample](sample-mcp-server-config.json).
+- Provide a starting status (e.g., refresh)
+
+### Use Assistant
+
+- Select the **assist** graph
+- And ask away!
+
+
 ## MCP Wrapper
 
 [`mcp_wrapper.py`](src/langgraph_mcp/mcp_wrapper.py) employs a Strategy Pattern using an abstract base class (`MCPSessionFunction`) to define a common interface for executing various operations on MCP servers. The pattern facilitates:
@@ -50,6 +65,8 @@ langgraph dev
 	- `MCPSessionFunction` defines an async `__call__` method as a contract for all session functions.
 2.	Concrete Implementations:
     - `RoutingDescription` class implements fetching routing information based on tools, prompts, and resources.
+    - `GetTools` class implements fetching tools for the MCP server and transforming them to the format consumable by LangGraph.
+    - `RunTool` class implements invoking a tool on MCP server and returning its output.
 3.	Processor Function:
 	- `apply` serves as a unified executor. It:
 	    - Initializes a session using `stdio_client` from `mcp` library.

--- a/langgraph.json
+++ b/langgraph.json
@@ -2,7 +2,7 @@
   "dependencies": ["."],
   "graphs": {
     "build_router_graph": "./src/langgraph_mcp/build_router_graph.py:graph",
-    "router_graph": "./src/langgraph_mcp/router_graph.py:graph"
+    "assistant_graph": "./src/langgraph_mcp/assistant_graph.py:graph"
   },
   "env": ".env"
 }

--- a/src/langgraph_mcp/__init__.py
+++ b/src/langgraph_mcp/__init__.py
@@ -1,33 +1,16 @@
-"""Retrieval Graph Module
+"""MCP Router using LangGraph
 
-This module provides a conversational retrieval graph system that enables
-intelligent document retrieval and question answering based on user inputs.
+This module routes user message to appropriate MCP server.
+- build_router_graph: builds and indexes a document for each MCP (Model Context Protocol) server
+- assistant_graph: uses the index to:
+    - decide which MCP server to route the user message to
+    - decide which tool(s) in the MCP server to call
+    - call the tool(s) and return the result(s)
 
-The main components of this system include:
+"""
 
-1. A state management system for handling conversation context and document retrieval.
-2. A query generation mechanism that refines user inputs into effective search queries.
-3. A document retrieval system that fetches relevant information based on generated queries.
-4. A response generation system that formulates answers using retrieved documents and conversation history.
-
-The graph is configured using customizable parameters defined in the Configuration class,
-allowing for flexibility in model selection, retrieval methods, and system prompts.
-
-Key Features:
-- Adaptive query generation for improved document retrieval
-- Integration with various retrieval providers (e.g., Elastic, Pinecone, MongoDB)
-- Customizable language models for query and response generation
-- Stateful conversation management for context-aware interactions
-
-Usage:
-    The main entry point for using this system is the `graph` object exported from this module.
-    It can be invoked to process user inputs and generate responses based on retrieved information.
-
-For detailed configuration options and usage instructions, refer to the Configuration class
-and individual component documentation within the retrieval_graph package.
-"""  # noqa
-
-from langgraph_mcp.router_graph import graph as router_graph
+from langgraph_mcp.assistant_graph import graph as assistant_graph
 from langgraph_mcp.build_router_graph import graph as build_router_graph
 
-__all__ = ["router_graph", "build_router_graph"]
+
+__all__ = ["assistant_graph", "build_router_graph"]

--- a/src/langgraph_mcp/configuration.py
+++ b/src/langgraph_mcp/configuration.py
@@ -51,6 +51,18 @@ class Configuration:
         },
     )
 
+    mcp_orchestrator_system_prompt: str = field(
+        default=prompts.MCP_ORCHESTRATOR_SYSTEM_PROMPT,
+        metadata={"description": "The system prompt used for MCP server orchestration."},
+    )
+
+    mcp_orchestrator_model: Annotated[str, {"__template_metadata__": {"kind": "llm"}}] = field(
+        default="openai/gpt-4o",
+        metadata={
+            "description": "The language model used for MCP server orchestration. Should be in the form: provider/model-name."
+        },
+    )
+
     @classmethod
     def from_runnable_config(
         cls: Type[T], config: Optional[RunnableConfig] = None

--- a/src/langgraph_mcp/prompts.py
+++ b/src/langgraph_mcp/prompts.py
@@ -1,5 +1,13 @@
 """Default prompts."""
 
+ROUTING_QUERY_SYSTEM_PROMPT = """Generate query to search the right Model Context Protocol (MCP) server document that may help with user's message. Previously, we made the following queries:
+    
+<previous_queries/>
+{queries}
+</previous_queries>
+
+System time: {system_time}"""
+
 ROUTING_RESPONSE_SYSTEM_PROMPT = """You are a helpful AI assistant responsible for selecting the most relevant Model Context Protocol (MCP) server for the user's query. Use the following retrieved server documents to make your decision:
 
 {retrieved_docs}
@@ -15,10 +23,19 @@ Guidelines:
 
 System time: {system_time}"""
 
-ROUTING_QUERY_SYSTEM_PROMPT = """Generate query to search the right Model Context Protocol (MCP) server document that may help with user's message. Previously, we made the following queries:
-    
-<previous_queries/>
-{queries}
-</previous_queries>
+MCP_ORCHESTRATOR_SYSTEM_PROMPT = """You are an intelligent assistant tasked with solving user queries efficiently by leveraging a set of specialized tools. Your primary responsibilities include understanding the conversation, selecting the most appropriate tools, and synthesizing accurate, actionable responses.
 
-System time: {system_time}"""
+### Objectives:
+1. Analyze the user's query to understand their intent and context.
+2. Select and use the most relevant tools to fulfill the query.
+3. Combine tool outputs logically to provide a clear and comprehensive response.
+4. If the tools do not support solving the query, respond with "{idk_response}".
+
+### Guidelines:
+- Before using a tool, ensure you understand its input requirements and expected outputs.
+- Use tools iteratively if necessary and combine their outputs to construct a meaningful response.
+- Handle errors gracefully, and document any assumptions or limitations.
+- Ensure your response is concise, clear, and directly addresses the user's query.
+
+System time: {system_time}
+"""

--- a/src/langgraph_mcp/state.py
+++ b/src/langgraph_mcp/state.py
@@ -98,5 +98,4 @@ class State(InputState):
     retrieved_docs: list[Document] = field(default_factory=list)
     """Populated by the retriever. This is a list of documents that the agent can reference."""
 
-    # Feel free to add additional attributes to your state as needed.
-    # Common examples include retrieved documents, extracted entities, API connections, etc.
+    current_mcp_server: str = field(default="")


### PR DESCRIPTION
- `router_graph` is now just a sub-graph in the new `assistant_graph`
- router sub-graph routes to an mcp server
- new mcp orchestrator node uses new wrapper `GetTools(MCPSessionFunction)` to get mcp server tools. dynamically binds them to a language model. decides which tool to use to serve the conversation
- new mcp tool node uses new `RunTool(MCPSessionFunction)` to run tool on mcp server. and add tool output in a tool message.

- assistant graph decides how to handle user message conditionally
    - directly go to mcp server orchestration (if there is an active mcp server in the state)
    - otherwise use the router-subgraph to route to one

- route node decides how to proceed
    - go to mcp orchestrator node (if an mcp server has been selected to route to)
    - if no mcp server was found relevant - go to end

- mcp orchestrator node decides what to do next
    - go to router-subgraph if an `i don't know` (IDK) response is generated (i.e., no tool in current mcp server seems a valid candidate to handle the current conversation context
    - go to mcp_tool if a tool_call is suggested by the language model
    - go to end if a normal ai response is generated
    
- new prompt + configurations added for mcp orchestrator node