### PR TITLE
Adding ambiguity support

### DIFF
--- a/src/langgraph_mcp/assistant_graph.py
+++ b/src/langgraph_mcp/assistant_graph.py
@@ -16,6 +16,7 @@ from langgraph_mcp.utils import get_message_text, load_chat_model, format_docs
 
 NOTHING_RELEVANT = "Nothing relevant found"  # When available MCP servers seem to be irrelevant for the query
 IDK_RESPONSE = "Unable to assist with this query."  # Default response where the current MCP Server can't help
+AMBIGUITY_PREFIX = "Ambiguity:"  # Prefix to indicate ambiguity when asking the user for clarification
 
 ##################  MCP Server Router: Sub-graph Components  ###################
 
@@ -122,7 +123,7 @@ async def route(
         config,
     )
     response = await model.ainvoke(message_value, config)
-    if response.content == NOTHING_RELEVANT:
+    if response.content == NOTHING_RELEVANT or response.content.startswith(AMBIGUITY_PREFIX):
         return {
             "messages": [response]
         }

--- a/src/langgraph_mcp/prompts.py
+++ b/src/langgraph_mcp/prompts.py
@@ -8,20 +8,23 @@ ROUTING_QUERY_SYSTEM_PROMPT = """Generate query to search the right Model Contex
 
 System time: {system_time}"""
 
-ROUTING_RESPONSE_SYSTEM_PROMPT = """You are a helpful AI assistant responsible for selecting the most relevant Model Context Protocol (MCP) server for the user's query. Use the following retrieved server documents to make your decision:
+RROUTING_RESPONSE_SYSTEM_PROMPT = """You are a helpful AI assistant responsible for selecting the most relevant Model Context Protocol (MCP) server for the user's query. Use the following retrieved server documents to make your decision:
 
 {retrieved_docs}
 
 Objective:
 1. Identify the MCP server that is best equipped to address the user's query based on its provided tools and prompts.
-2. If no MCP server is sufficiently relevant, return "{nothing_relevant}".
+2. If multiple servers seem to be relevant, ask the user for clarification.
+3. If no MCP server is sufficiently relevant, return "{nothing_relevant}".
 
 Guidelines:
 - Carefully analyze the tools, prompts, and resources described in each retrieved document.
 - Match the user's query against the capabilities of each server.
-- Your response should be concise and include only the server id (e.g., "mcp_server_id"), or "{nothing_relevant}" if no server is applicable.
+- Your response should be concise and include only the server id (e.g., "mcp_server_id"), or "{nothing_relevant}" if no server is applicable, or ask user for clarification if there is an ambiguity between multiple servers.
+- In case of ambiguity, i.e., while asking the user for clarification, make sure to start your response with "{ambiguity_prefix} ".
 
-System time: {system_time}"""
+System time: {system_time}
+"""
 
 MCP_ORCHESTRATOR_SYSTEM_PROMPT = """You are an intelligent assistant tasked with solving user queries efficiently by leveraging a set of specialized tools. Your primary responsibilities include understanding the conversation, selecting the most appropriate tools, and synthesizing accurate, actionable responses.
 


### PR DESCRIPTION
Routing may have ambiguities. E.g., user says "create an issue" and there are mcp servers for github, jira, trello. All those servers offer issue creation tools, which makes it ambiguous for the router. In this PR, I have added the following to address such ambiguities:
- Enhanced the routing prompt to look for ambiguities and ask the user for clarification.
- In addition to `nothing relevant` cases, `route` node edges to END for scenarios requiring user clarification.